### PR TITLE
Fix for line breaking algorithm

### DIFF
--- a/canvas-text-wrapper.js
+++ b/canvas-text-wrapper.js
@@ -158,29 +158,29 @@
     }
 
     function breakText(words) {
+      lines = [];
       for (var i = 0, j = 0; i < words.length; j++) {
         lines[j] = '';
 
-        if (opts.lineBreak === 'auto') {
-          if (context.measureText(lines[j] + words[i]).width > MAX_TXT_WIDTH) {
-            break;
-          } else {
-            while ((context.measureText(lines[j] + words[i]).width <= MAX_TXT_WIDTH) && (i < words.length)) {
+        var inserted = false;
+        while ((opts.lineBreak === 'auto') && (context.measureText(lines[j] + words[i]).width <= MAX_TXT_WIDTH) && (i < words.length)) {
 
-              lines[j] += words[i] + ' ';
-              i++;
+          inserted = true;
+          lines[j] += words[i] + ' ';
+          i++;
 
-              if (opts.allowNewLine) {
-                for (var k = 0; k < newLineIndexes.length; k++) {
-                  if (newLineIndexes[k] === i) {
-                    j++;
-                    lines[j] = '';
-                    break;
-                  }
-                }
+          if (opts.allowNewLine) {
+            for (var k = 0; k < newLineIndexes.length; k++) {
+              if (newLineIndexes[k] === i) {
+                j++;
+                lines[j] = '';
+                break;
               }
             }
           }
+        }
+
+        if (inserted) {
           lines[j] = lines[j].trim();
         } else {
           lines[j] = words[i];


### PR DESCRIPTION
When used with `sizeToFill`, when measuring the one-size too big text, the previous version was leaving a line with the last character as a leftover that was never cleaned up (even when the whole word has been fitted into a previous line after decreasing font size), resulting in a last character being duplicated.

Also, in some cases, when nothing was inserted into a line during `breakText`, the algorithm was entering a loop that was adding an infinite number of empty lines, causing the browser to crash.