### PR TITLE
Fix for line breaking algorithm

### DIFF
--- a/canvas-text-wrapper.js
+++ b/canvas-text-wrapper.js
@@ -158,6 +158,7 @@
     }
 
     function breakText(words) {
+      lines = [];
       for (var i = 0, j = 0; i < words.length; j++) {
         lines[j] = '';
 


### PR DESCRIPTION
When used with `sizeToFill`, when measuring the one-size too big text, the previous version was leaving a line with the last character as a leftover that was never cleaned up (even when the whole word has been fitted into a previous line after decreasing font size), resulting in a last character being duplicated.