### PR TITLE
Use context.textAlign for horizontal alignment

### DIFF
--- a/canvas-text-wrapper.js
+++ b/canvas-text-wrapper.js
@@ -114,6 +114,7 @@
       }
 
       setVertAlign();
+      setHorizAlign();
       drawText();
     }
 
@@ -246,8 +247,6 @@
 
     function drawText() {
       for (var i = 0; i < lines.length; i++) {
-        setHorizAlign(lines[i]);
-
         textPos.y = parseInt(textPos.y) + lineHeight;
         context.fillText(lines[i], textPos.x, textPos.y);
 
@@ -261,11 +260,13 @@
       }
     }
 
-    function setHorizAlign(line) {
+    function setHorizAlign() {
+      context.textAlign = opts.textAlign;
+
       if (opts.textAlign == 'center') {
-        textPos.x = (EL_WIDTH - context.measureText(line).width) / 2;
+        textPos.x = EL_WIDTH / 2;
       } else if (opts.textAlign == 'right') {
-        textPos.x = EL_WIDTH - context.measureText(line).width - opts.paddingX;
+        textPos.x = EL_WIDTH - opts.paddingX;
       } else {
         textPos.x = opts.paddingX;
       }


### PR DESCRIPTION
Relying on native `context.textAlign` instead of calculating `x` starting position using text measurement allowed me to properly handle RTL text direction, when the text is drawn from the specified point to the left, not to the right.

I'm not sure why it wasn't like this, so you might have another ideas how to solve RTL text direction problem like this (left-aligned text is written to the left from the starting point): 

![image](https://cloud.githubusercontent.com/assets/1309057/13737580/b75ed246-e9be-11e5-91c6-77411579d7cd.png)
